### PR TITLE
Version 1.1 -> 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,9 @@
 
 ### Added
 - Changelog file
+
+
+## [1.2] - 2021-06-05
+### Fixed
+- Fixed error messages to flag ordered lists (olo) as an UnsupportedFeature
+- Fixed validator to flag unknown properties as errors

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UCO-Utility-Pre-0.7.0-Validator
 
-## Description -  (Beta Release  Version 1.1)
+## Description -  (Beta Release  Version 1.2)
 
 The UCO/CASE Validation Toolkit provides the capability to validate JSON-LD data files against a turtle-file based ontology such as the Unified Cyber Ontology (UCO) and Cyber-Investigation Analysis Standard Expression (CASE).
 

--- a/src/precondition.py
+++ b/src/precondition.py
@@ -134,7 +134,7 @@ def autogenerate_empty_prefix(text, prefix_length, alphabet):
 
     # If we found all possible strings (this is really unlikely),
     # we probably need to increase the string length
-    if len(non_candidate_prefix_strings) == len(alphabet):
+    if len(non_candidate_prefix_strings) == len(alphabet)**prefix_length:
         raise Exception('Could not find unused prefix sequence!')
 
     # Look for a prefix string that is not is the non_candidate set

--- a/src/validator.py
+++ b/src/validator.py
@@ -266,6 +266,7 @@ def validate_range_constraints(pvt_dict, ontology_property_ranges, ancestor_clas
         if property_range:
             for value, value_type in vt_dict.items():
                 if not (property_range == value_type or property_range in ancestor_classes.get(value_type, [])):
+                    #import pdb; pdb.set_trace()
                     error_messages.append(ConstraintError(
                         message="property's value {} is a {} but must be a {}".format(
                             '' if isinstance(value, rdflib.term.BNode) else value,
@@ -309,7 +310,7 @@ def validate_literal(literal, constraints, context):
                    message='Literal {} has datatype that is not a URIRef: {}'.format(literal, literal.datatype))]
 
     # If Literal datatype is an XSD type, validate it and return list of error messages
-    if str(literal.datatype).startswith(XSD) or str(literal.datatype).startswith('xsd:') or str(literal.datatype).startswith('xs:'):
+    if str(literal.datatype).startswith(str(XSD)) or str(literal.datatype).startswith('xsd:') or str(literal.datatype).startswith('xs:'):
         return validate_xsd(str(literal), literal.datatype)
 
     # If we're here, Literal datatype is a URIRef and not an XSD type.


### PR DESCRIPTION
Updated CHANGELOG.md and README.md
Modified src/validator.py as follows:
   To flag ordered lists (olo) as UnsupportedFeature instead of random bnode errors.
   To flag properties not in the ontology as unknown property
     Version 1.1 assumed an open model, where unknown properties are acceped as unconstrained.
     Version 1.2 uses a less-open model, where
          properties not in the ontology are rejected
          properties not known to the class (but known to the ontology) are accepted as constrained.