### PR TITLE
Address TypeError with XSD namespace

### DIFF
--- a/src/validator.py
+++ b/src/validator.py
@@ -291,7 +291,7 @@ def validate_literal(literal, constraints, context):
                    message='Literal {} has datatype that is not a URIRef: {}'.format(literal, literal.datatype))]
 
     # If Literal datatype is an XSD type, validate it and return list of error messages
-    if str(literal.datatype).startswith(XSD) or str(literal.datatype).startswith('xsd:') or str(literal.datatype).startswith('xs:'):
+    if str(literal.datatype).startswith(str(XSD)) or str(literal.datatype).startswith('xsd:') or str(literal.datatype).startswith('xs:'):
         return validate_xsd(str(literal), literal.datatype)
 
     # If we're here, Literal datatype is a URIRef and not an XSD type.


### PR DESCRIPTION
I encountered this error at the end of a decently long stack trace:

    TypeError: startswith first arg must be str or a tuple of str, not DefinedNamespaceMeta

while attempting to validate this file:
https://github.com/casework/CASE-Examples/blob/master/examples/illustrations/exif_data/exif_data.json

(The Make target that failed was check-0.3.0, for CASE 0.3.0 and
UCO 0.5.0.  These version details might be moot.)

Casting the XSD namespace variable as a string fixed the
input-type error.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>